### PR TITLE
Problems in sequencing parsers.

### DIFF
--- a/Parsing.Linq.Test/ParserTest.cs
+++ b/Parsing.Linq.Test/ParserTest.cs
@@ -270,5 +270,65 @@ namespace System.Parsing.Linq.Test
 
             Assert.IsTrue(Enumerable.SequenceEqual(elements, result));
         }
+
+        [TestMethod]
+        public void FromRegexTest()
+        {
+            var parser = Parser.FromRegex("[aoeiu]");
+            var result = parser.Parse("cat");
+
+            Assert.IsFalse(result.IsMissing);
+            Assert.AreEqual("a", result.Value);
+            Assert.AreEqual(1, result.Position);
+            Assert.AreEqual(1, result.Length);
+        }
+
+        [TestMethod]
+        public void OffsetTest()
+        {
+            var parser = Parser.FromRegex("word");
+            var line = @"word abcdefgh";
+
+            var result = parser.Parse(line, 5);
+            Assert.IsTrue(result.IsMissing);
+        }
+
+        [TestMethod]
+        public void SequencingTest()
+        {
+            var parser =
+                from hello in Parser.FromText("Hello")
+                from space in CharParsers.WhiteSpace
+                from world in Parser.FromText("world")
+                from period in Parser.FromChar('.')
+                select hello + world;
+
+            Assert.IsTrue(CanParse(parser, "Hello world."));
+        }
+
+        [TestMethod]
+        public void SequencingRegexTest()
+        {
+            var parser =
+                from hello in Parser.FromRegex("Hello")
+                from space in CharParsers.WhiteSpace
+                from world in Parser.FromText("world")
+                from period in Parser.FromChar('.')
+                select hello + world;
+
+            Assert.IsTrue(CanParse(parser, "preffix Hello world."));
+        }
+
+        [TestMethod]
+        public void SequencingCorrectOffsetIsSetTest()
+        {
+            var parser =
+                from a in Parser.FromRegex("aaa")
+                from b in Parser.FromText("bbb")
+                select a + b;
+
+            Assert.IsTrue(CanParse(parser, "preffix...aaabbb...suffix"));
+            Assert.IsFalse(CanParse(parser, "123bbbaaa"));
+        }
     }
 }

--- a/Parsing.Linq/Parser.Factories.cs
+++ b/Parsing.Linq/Parser.Factories.cs
@@ -76,7 +76,7 @@ namespace System.Parsing.Linq
                 {
                     var match = regex.Match(text, offset);
                     return match.Success
-                        ? new ParserResult<T>(select(match), text, offset, match.Length)
+                        ? new ParserResult<T>(select(match), text, match.Index, match.Length)
                         : ParserResult<T>.Missing;
                 });
         }

--- a/Parsing.Linq/Parser.Operators.cs
+++ b/Parsing.Linq/Parser.Operators.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.IO;
 
 namespace System.Parsing.Linq
 {

--- a/Parsing.Linq/Parser.Operators.cs
+++ b/Parsing.Linq/Parser.Operators.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 
 namespace System.Parsing.Linq
 {
@@ -28,9 +29,9 @@ namespace System.Parsing.Linq
                     var res1 = parser.Parse(text, offset);
                     if (res1.IsMissing) return ParserResult<TValue2>.Missing;
                     var val1 = res1.Value;
-                    var res2 = selector(val1).Parse(text, offset + res1.Length);
+                    var res2 = selector(val1).Parse(text, res1.Position + res1.Length);
                     if (res2.IsMissing) return ParserResult<TValue2>.Missing;
-                    return new ParserResult<TValue2>(projector(val1, res2.Value), text, offset, res1.Length + res2.Length);
+                    return new ParserResult<TValue2>(projector(val1, res2.Value), text, res1.Position, res1.Length + res2.Length);
                 });
         }
 


### PR DESCRIPTION
The ParseResult position is not correct when parser with regex is used. Similarly in the SelectMany a wrong offset is passed to the second parser.

Unfortunately the proposed change doesn't solve all problems. For example:

``` C#
var parser =
    from a in Parser.FromRegex("aaa")
    from b in Parser.FromRegex("bbb")
    from c in Parser.FromRegex("bbb")
    select a + b + c;
```

This parser will successfully parse the string _123aaa123bbb_, although there isn't a second group of _bbb_. In this case it's hard to set correct position and length to the first match (or at least I am not sure what they should be). Nevertheless  I would use this line in SelectMany rather than the current one:

``` C#
return new ParserResult<TValue2>(projector(val1, res2.Value), text, res1.Position, res2.position + res2.Length - res1.Position);
```

Alternatively the regex match could be counted as successful only if it starts in the beginning of the searched text.
